### PR TITLE
feat: add username in the plugin-bells options

### DIFF
--- a/src/configure.js
+++ b/src/configure.js
@@ -50,6 +50,7 @@ module.exports = co.wrap(function * (output) {
     plugin: 'ilp-plugin-bells',
     options: {
       account: 'https://' + wallet.hostname + '/ledger/accounts/' + wallet.username,
+      username: wallet.username,
       password: wallet.password
     }
   }  


### PR DESCRIPTION
ILP Kit needs this to automatically create the ledger account.