### PR TITLE
Feat: track version that generated env list

### DIFF
--- a/src/configure.js
+++ b/src/configure.js
@@ -90,6 +90,8 @@ module.exports = co.wrap(function * (output) {
   env.CONNECTOR_PORT = env.CONNECTOR_PORT || '4000'
   env.LEDGER_RECOMMENDED_CONNECTORS = wallet.username
 
+  env.ILP_KIT_CLI_VERSION = require('../package.json').version
+
   // write the environment to a docker-compatible env-file
   printInfo('Writing enviroment to "' + output + '"...')
   fs.writeFileSync(


### PR DESCRIPTION
sets the variable `ILP_KIT_CLI_VERSION` to the ILP Kit CLI version that's running `configure`.